### PR TITLE
perf: Rewrite bulk_insert_records with multi-row INSERT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,44 +35,11 @@ uvx tox -e lint      # check
 uvx tox -e format    # auto-fix
 ```
 
-## Performance benchmarking
+## Performance
 
-### Setup
+See [PERFORMANCE.md](PERFORMANCE.md) for benchmarks, timing breakdown, and next steps.
 
-Start MSSQL and create a config file:
-
-```bash
-docker compose up -d sink
-cat > benchmark_config.json <<'EOF'
-{"schema":"dbo","username":"sa","password":"P@55w0rd","host":"localhost","port":"1433","database":"master","table_prefix":"bench_"}
-EOF
-```
-
-### Generate synthetic data and time a run
-
-```bash
-uv run python target_mssql/tests/generate_benchmark_data.py 100000 \
-  | { time uv run target-mssql --config benchmark_config.json; } 2>&1 \
-  | grep -E "METRIC|cpu"
-```
-
-### Baseline (2026-05-11, local Docker MSSQL 2022, upsert path)
-
-| Records | Wall time | Throughput |
-|---------|-----------|------------|
-| 1,000   | 1.63s     | ~610 rec/s |
-| 10,000  | 2.77s     | ~3,610 rec/s |
-| 100,000 | 23.4s     | ~4,270 rec/s |
-
-Fixed startup + first-batch overhead is ~1.3s. At steady state each 10,000-record batch
-takes ~2s through the temp-table + MERGE path.
-
-### Key bottleneck
-
-Each batch goes: deduplicate in memory → `INSERT` into `#temp` table → `MERGE INTO` main.
-The MERGE is the dominant cost. SDK default batch size is 10,000 rows (`MAX_SIZE_DEFAULT`).
-
-Key files for performance work:
+Key files:
 - `target_mssql/sinks.py` — `process_batch`, `bulk_insert_records`, `merge_upsert_from_table`
 - `target_mssql/connector.py` — connection and schema management
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,65 @@
+# Performance notes
+
+## How to benchmark
+
+Start MSSQL and create a config file:
+
+```bash
+docker compose up -d sink
+cat > benchmark_config.json <<'EOF'
+{"schema":"dbo","username":"sa","password":"P@55w0rd","host":"localhost","port":"1433","database":"master","table_prefix":"bench_"}
+EOF
+```
+
+Generate synthetic data and time a run:
+
+```bash
+uv run python target_mssql/tests/generate_benchmark_data.py 100000 \
+  | { time uv run target-mssql --config benchmark_config.json; } 2>&1 \
+  | grep -E "METRIC|cpu"
+```
+
+## Baseline (2026-05-11, local Docker MSSQL 2022, upsert path)
+
+| Records | Wall time | Throughput |
+|---------|-----------|------------|
+| 1,000   | 1.63s     | ~610 rec/s |
+| 10,000  | 2.77s     | ~3,610 rec/s |
+| 100,000 | 23.4s     | ~4,270 rec/s |
+
+Fixed startup + first-batch overhead is ~1.3s. At steady state each 10,000-record batch
+takes ~2s through the temp-table + MERGE path.
+
+## Batch timing breakdown (10k records, upsert path)
+
+| Step | Time | % |
+|------|------|---|
+| dedupe in memory | 0.12s | 6% |
+| `prepare_table` (DDL check) | 0.10s | 5% |
+| `create_temp_table` (DROP+SELECT INTO) | 0.02s | 1% |
+| **`bulk_insert` into `#temp`** | **1.55s** | **83%** |
+| `MERGE INTO` main table | 0.07s | 4% |
+
+## Key finding
+
+The bottleneck is **SQL Server's INSERT throughput into tempdb** (~6,000–7,000 rows/sec).
+Confirmed by trying: multi-row INSERTs (same speed), `WITH (TABLOCK)` (marginal),
+`SET NOCOUNT ON` (no effect), inline-VALUES MERGE (slower — 2.1s vs 1.7s), and measuring
+the no-primary-key path (same ~1.7s for 10k rows directly into the main table).
+The wall is SQL Server I/O in Docker, not Python or network overhead.
+
+## What was changed
+
+`bulk_insert_records` now uses explicit multi-row `INSERT … VALUES (…),(…),…` statements
+chunked to SQL Server's 2100-parameter limit, with `WITH (TABLOCK)` on temp table inserts.
+This is cleaner than SQLAlchemy `executemany` (which also returned a wrong `rowcount`)
+and enables minimal logging on the heap temp table.
+
+## Remaining levers to explore
+
+- **Larger `batch_size_rows`** — the 0.1s `prepare_table` + 0.02s temp-table DDL overhead
+  is paid once per batch; fewer bigger batches would amortize it.
+  Set via `{"batch_size_rows": 50000}` in config.
+- **Skip `prepare_table` when schema is unchanged** — saves ~0.1s per batch after the first.
+- **SQL Server bulk-copy (BCP)** — would bypass tempdb logging entirely but requires
+  file-system access not available through pymssql.

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -7,7 +7,6 @@ import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
-import sqlalchemy
 from singer_sdk import metrics
 from singer_sdk.connectors.sql import SQLConnector
 from singer_sdk.helpers._conformers import replace_leading_digit
@@ -18,7 +17,6 @@ from target_mssql.connector import mssqlConnector
 
 if TYPE_CHECKING:
     from singer_sdk.plugin_base import PluginBase
-    from sqlalchemy.engine import CursorResult
 
 
 class mssqlSink(SQLSink):
@@ -98,9 +96,11 @@ class mssqlSink(SQLSink):
         is_temp_table: bool = False,
     ) -> int | None:
         """Bulk insert records to an existing destination table.
-        The default implementation uses a generic SQLAlchemy bulk insert operation.
-        This method may optionally be overridden by developers in order to provide
-        faster, native bulk uploads.
+
+        Uses multi-row INSERT statements chunked to stay within SQL Server's
+        2100-parameter-per-statement limit. TABLOCK enables minimally-logged
+        writes into the heap temp table, which is faster than row-by-row logging.
+
         Args:
             full_table_name: the target table name.
             schema: the JSON schema for the new table, to be used when inferring column
@@ -110,30 +110,37 @@ class mssqlSink(SQLSink):
         Returns:
             True if table exists, False if not, None if unsure or undetectable.
         """
-        insert_sql = self.generate_insert_statement(
-            full_table_name,
-            schema,
-        )
-        if isinstance(insert_sql, str):
-            insert_sql = sqlalchemy.text(insert_sql)
-
-        self.logger.info("Inserting with SQL: %s", insert_sql)
-
         columns = self.column_representation(schema)
+        col_names = [col.name for col in columns]
 
-        # temporary fix to ensure missing properties are added
-        insert_records = []
-        for record in records:
-            insert_record = {}
-            for column in columns:
-                insert_record[column.name] = record.get(column.name)
-            insert_records.append(insert_record)
+        insert_records = [{col: record.get(col) for col in col_names} for record in records]
 
+        if not insert_records:
+            return 0
+
+        quote = self.connector._dialect.identifier_preparer.quote
+        quoted_cols = ", ".join(quote(c) for c in col_names)
+        row_placeholder = "(" + ", ".join(["%s"] * len(col_names)) + ")"
+
+        # SQL Server hard limit: 2100 parameters per statement.
+        rows_per_stmt = max(1, 2100 // len(col_names))
+
+        # TABLOCK enables minimally-logged bulk inserts into heap tables (temp tables
+        # created via SELECT INTO have no clustered index, so they qualify).
+        tablock = " WITH (TABLOCK)" if is_temp_table else ""
+
+        total = 0
         with self.connection.begin():
-            cursor: CursorResult = self.connection.execute(insert_sql, insert_records)
+            for offset in range(0, len(insert_records), rows_per_stmt):
+                chunk = insert_records[offset : offset + rows_per_stmt]
+                placeholders = ", ".join([row_placeholder] * len(chunk))
+                sql = f"INSERT INTO {full_table_name}{tablock} ({quoted_cols}) VALUES {placeholders}"  # noqa: S608
+                params = tuple(row[col] for row in chunk for col in col_names)
+                self.connection.exec_driver_sql(sql, params)
+                total += len(chunk)
 
         with metrics.record_counter(full_table_name) as record_counter:
-            record_counter.increment(cursor.rowcount)
+            record_counter.increment(total)
 
     def column_representation(
         self,
@@ -165,9 +172,9 @@ class mssqlSink(SQLSink):
         schema = self.conform_schema(self.schema)
 
         if self.key_properties:
-            deduped_records = {
-                frozenset(record[k] for k in self.key_properties): record for record in conformed_records
-            }.values()
+            deduped_records = list(
+                {frozenset(record[k] for k in self.key_properties): record for record in conformed_records}.values()
+            )
 
             self.logger.info(f"Preparing table {self.full_table_name}")
             self.connector.prepare_table(


### PR DESCRIPTION
## Summary

- Replaces SQLAlchemy `executemany` in `bulk_insert_records` with explicit multi-row `INSERT … VALUES (…),(…),…` statements chunked to SQL Server's 2100-parameter-per-statement limit
- Adds `WITH (TABLOCK)` on temp-table inserts to enable minimally-logged writes into the heap table
- Fixes `cursor.rowcount` returning the wrong value (was ~44 regardless of actual row count); now tracks the true total
- Materialises `deduped_records` as a `list` so the same iterable can be consumed by `bulk_insert_records`
- Adds `target_mssql/tests/generate_benchmark_data.py` and `PERFORMANCE.md` with baseline numbers and investigation findings

## Investigation findings

The `bulk_insert` step (INSERT into temp table) accounts for **83% of batch time** (~1.55s of ~1.87s per 10k-record batch). We tried multi-row INSERTs, `TABLOCK`, `SET NOCOUNT ON`, and an inline-VALUES MERGE approach — none materially changed the throughput. The wall is SQL Server's tempdb write speed in Docker (~6–7k rows/sec), not Python or driver overhead. See `PERFORMANCE.md` for the full breakdown and remaining levers to explore.

## Test plan

- [x] All existing tests pass (`uv run pytest --capture=no`)
- [x] 100k benchmark runs to completion without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)